### PR TITLE
[update] use ETS over a map struct when holding sockets

### DIFF
--- a/test/socket_drano_test.exs
+++ b/test/socket_drano_test.exs
@@ -68,7 +68,7 @@ defmodule SocketDranoTest do
       %{pid: self()}
     )
 
-    assert SocketDrano.socket_count() == :not_running
+    assert SocketDrano.socket_count() == :undefined
 
     spec = SocketDrano.child_spec(refs: [], shutdown_delay: 10_000)
     start_supervised!(spec)


### PR DESCRIPTION
use ETS over a map struct when holding sockets so we can read/write from/to it concurrently and it don't become a bottleneck