### PR TITLE
[add] support new drain_only a percentage of connections strategy

### DIFF
--- a/lib/socket_drano.ex
+++ b/lib/socket_drano.ex
@@ -383,6 +383,7 @@ defmodule SocketDrano do
 
   defp validate_strategy!({:drain_only, percent, batch_size_percent, time})
        when is_integer(percent) and
+              is_integer(batch_size_percent) and
               percent > 0 and
               percent <= 100 and
               batch_size_percent > 0 and


### PR DESCRIPTION
drain only a percentage of sockets from socket pool, in percentage batches, so `{:drain_only, 25, 25, 100}` will drain 25% of total sockets, in batches of 25% every 100ms, this is because as we may handle thousands of connections, so we don’t want to drain a big set at once